### PR TITLE
fix private key download data url

### DIFF
--- a/app/assets/javascripts/views/keypair/download.coffee
+++ b/app/assets/javascripts/views/keypair/download.coffee
@@ -11,4 +11,4 @@ class Keypair.Views.Download extends Backbone.View
     {href: @dataUri()}
 
   dataUri: ->
-    "data:application/x-pem-file,#{encodeURIComponent(@app.keypair.privateKey)}"
+    "data:application/x-pem-file,#{encodeURIComponent(@app.keypair.privateKeyPem)}"

--- a/features/key_generation.feature
+++ b/features/key_generation.feature
@@ -10,6 +10,7 @@ Feature: Key Generation
     And I press "Generate Key"
     And I wait an eternity
     Then I should see "Download Private Key"
+    And "Download Private Key" should contain the private key
 
     When I follow "Done"
     Then I should see "+"

--- a/features/step_definitions/key_steps.rb
+++ b/features/step_definitions/key_steps.rb
@@ -29,6 +29,10 @@ owQY
 -----END ENCRYPTED PRIVATE KEY-----
 EOF
 
+And /^"Download Private Key" should contain the private key$/ do
+  find('a[download="swordfish.pem"]')['href'].should =~ /BEGIN%20ENCRYPTED%20PRIVATE%20KEY/
+end
+
 Given '"$email" has generated a key' do |email|
   user = User.first(:email => email)
   user.public_key = $public_key


### PR DESCRIPTION
The wrong variable was used for accessing the generated private key resulting in swordfish.pem with "undefined". This fixes it and adds a test. I'm not very familiar with cucumber so I winged the test as best I could, since the generated key is different each time I made it check for the `BEGIN PRIVATE KEY` text which should be good enough.
