### PR TITLE
Errors on Incorrect Passphrase

### DIFF
--- a/app/assets/javascripts/templates/keypair/unlock.mustache
+++ b/app/assets/javascripts/templates/keypair/unlock.mustache
@@ -2,6 +2,7 @@
   <h1>Unlock</h1>
 
   <p>Enter your passphrase to unlock your private key.</p>
+  <p class="error"></p>
 
   <input class="wide" type="password" name="passphrase" placeholder="Enter Your Passphrase">
 

--- a/app/assets/javascripts/views/keypair/unlock.coffee
+++ b/app/assets/javascripts/views/keypair/unlock.coffee
@@ -17,6 +17,7 @@ class Keypair.Views.Unlock extends Backbone.View
     if @app.keypair.unlock(@$('input[type=password]').val())
       Backbone.history.navigate '', true
     else
+      @$('p.error').text('Your passphrase was incorrect!')
       @$('input[type=password]').val('')
 
     false

--- a/app/assets/stylesheets/mockup.scss
+++ b/app/assets/stylesheets/mockup.scss
@@ -356,3 +356,7 @@ button, .button {
   text-shadow:1px 1px 0px #ffffff;
   text-align: center;
 }
+
+p.error {
+  color: red;
+}


### PR DESCRIPTION
Update `key/unlock` so that the user is told when they input the wrong passphrase rather than seemingly unlock.
