### PR TITLE
Support MongoLab automatically

### DIFF
--- a/config/initializers/mongo.rb
+++ b/config/initializers/mongo.rb
@@ -1,4 +1,4 @@
-uri      = URI.parse ENV["GH_MONGODB_URL"] || ENV["MONGODB_URI"] || ENV["MONGOHQ_URL"]
+uri      = URI.parse ENV["GH_MONGODB_URL"] || ENV["MONGODB_URI"] || ENV["MONGOHQ_URL"] || ENV["MONGOLAB_URL"]
 conn     = Mongo::Connection.from_uri(uri.to_s)
 database = uri.path.sub('/', '')
 database = "swordfish-#{Rails.env}" if database.blank?


### PR DESCRIPTION
MongoLab is yet another MongoDB host on Heroku. This commit automatically detects MongoLab.
