### PR TITLE
Open first item on first page load

### DIFF
--- a/app/assets/javascripts/routers/item_router.coffee
+++ b/app/assets/javascripts/routers/item_router.coffee
@@ -27,7 +27,9 @@ class @ItemRouter extends Backbone.Router
   items: =>
     # ensure items collection has access to the keypair
     @items.keypair ||= @app.keypair
-    @items.fetch()
+    @items.fetch().then (items) =>
+      if _.any(items)
+        @item _.first(items).id
 
   newItem: (id) =>
     @content new Item.Views.Create(collection: @items)

--- a/features/items.feature
+++ b/features/items.feature
@@ -20,8 +20,6 @@ Feature: Items
     And I press "Unlock"
     Then I should see "example.com"
 
-    When I follow "example.com"
-
     Then I should see "myusername"
     When I follow "reveal"
     Then I should see "mypassword"


### PR DESCRIPTION
Fixes #20

The line I removed from the Items feature tests this functionality, but it also removes a test for item list navigation.

I tried to test that with something like the following, but I think there are some timing issues and I'm unsure of the best way to handle that. It would be nice to have some fixtures or something, but given the encryption I'm not sure where to start with that.

Let me know if you have any thoughts. Thanks!

```
Scenario: Navigating the item list
  When I follow "New Item"
  And I fill in "Title" with "First item"
  And I fill in "Username" with "First username"
  And I fill in "Password" with "mypassword"
  And I fill in "Confirm" with "mypassword"
  And I press "Create"

  And I follow "New Item"
  And I fill in "Title" with "Second item"
  And I fill in "Username" with "Second username"
  And I fill in "Password" with "mypassword"
  And I fill in "Confirm" with "mypassword"
  And I press "Create"

  When I follow "First item"
  Then I should see "First username"

  When I follow "Second item"
  Then I should see "Second username"
```
