### PR TITLE
Update build status to reflect `master` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Swordfish [![Build Status](https://secure.travis-ci.org/github/swordfish.png)](http://travis-ci.org/github/swordfish)
+# Swordfish [![Build Status](https://secure.travis-ci.org/github/swordfish.png?branch=master)](http://travis-ci.org/github/swordfish)
 
 Swordfish is an experiment in building a group-optimized password management
 app. It is currently very alpha.


### PR DESCRIPTION
I was thrown off by the failed build status badge at first, until I realized it was not specifying the `master` branch. It's actually reflecting the last build which happens to be the `team` branch build, and that failed. :confused:

Not sure, but perhaps you want the `master` build status shown instead? Either way, a PR to fix that if you would like.
