### PR TITLE
only load guard/jasmine rake tasks in dev/test environments

### DIFF
--- a/lib/tasks/jasmine.rake
+++ b/lib/tasks/jasmine.rake
@@ -1,4 +1,5 @@
-if %(development test).include? ENV['RACK_ENV']
+begin
   require 'guard/jasmine/task'
   Guard::JasmineTask.new
+rescue LoadError
 end


### PR DESCRIPTION
This is to fix problems w/ e.g. running assets:precompile/db:migrate from a production environment
