### PR TITLE
Fix exception after changing keypair

### DIFF
--- a/app/assets/javascripts/routers/item_router.coffee
+++ b/app/assets/javascripts/routers/item_router.coffee
@@ -26,7 +26,7 @@ class @ItemRouter extends Backbone.Router
 
   items: =>
     # ensure items collection has access to the keypair
-    @itemsCollection.keypair ||= @app.keypair
+    @itemsCollection.keypair = @app.keypair
     @itemsCollection.fetch()
 
   newItem: (id) =>

--- a/spec/javascripts/routers/item_router_spec.coffee
+++ b/spec/javascripts/routers/item_router_spec.coffee
@@ -1,0 +1,28 @@
+#= require forge
+#= require application
+#= require models/keypair
+#= require routers/item_router
+
+describe 'ItemRouter', ->
+  describe 'items', ->
+    it 'should set the keypair on the collection if it does not exist', ->
+      app = Application
+      key1 = new Keypair("private1")
+      app.keypair = key1
+      router = new ItemRouter(app: app)
+      router.items()
+      expect(router.itemsCollection.keypair).toEqual(key1)
+
+    it 'should set the keypair on the collection to the new key if it does exist', ->
+      app = Application
+      key1 = new Keypair("private1")
+      key2 = new Keypair("private2")
+      app.keypair = key1
+      router = new ItemRouter(app: app)
+      router.items()
+      # Key1 should be set properly on the collection
+      expect(router.itemsCollection.keypair).toEqual(key1)
+      # Simulate the user changing keypairs
+      app.keypair = key2
+      router.items()
+      expect(router.itemsCollection.keypair).toEqual(key2)


### PR DESCRIPTION
Two changes here:
- Rename `@items` to `@itemsCollection` to make `item_router.coffee` more testable in Jasmine.
- Remove the `||=` in `item_router.coffee` to make sure the new keypair gets set properly when the user changes keypairs. Tests included.

Renaming the collection is more to make it easier to test the router in isolation.  Without that change the `items` function was getting clobbered by the `items` property in Jasmine. 

The blank page issue also mentioned in #66 is still there but appears to be unrelated to this exception.

My experience with Jasmine is pretty limited so let me know if you'd like anything done differently.
