### PR TITLE
Add "passphrase" to filtered parameters

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module Swordfish
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
+    config.filter_parameters += [:password, :passphrase]
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true


### PR DESCRIPTION
In local development, I could see my passphrase in the list Rails parameters
in plain text. This is because only the key `:password` was filtered. This
commit filters both `:password` and `:passphrase` to prevent passwords from
being logged in plain text.

/cc @bkeepers 
